### PR TITLE
Mudar a ordem de colunas na tela de alocação de bolsas

### DIFF
--- a/app/controllers/scholarship_durations_controller.rb
+++ b/app/controllers/scholarship_durations_controller.rb
@@ -30,7 +30,7 @@ class ScholarshipDurationsController < ApplicationController
     config.columns[:scholarship].clear_link
     config.columns[:enrollment].clear_link
     config.list.sorting = {:scholarship => 'ASC'}
-    config.list.columns = [:scholarship, :start_date, :cancel_date, :end_date, :enrollment]
+    config.list.columns = [:scholarship, :start_date, :end_date, :cancel_date, :enrollment]
     config.create.label = :create_scholarship_duration_label
     config.columns = [:scholarship, :enrollment, :start_date, :cancel_date, :end_date, :obs]
     config.columns[:scholarship].search_sql = 'scholarships.scholarship_number'


### PR DESCRIPTION
Colocar a coluna "data limite de concessão" antes da coluna "data de encerramento".
