### PR TITLE
Roles translations :: table columns are now translated

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -667,6 +667,9 @@ pt-BR:
          semester: "Semestre"
          enrollments: "Matrículas"
          class_enrollments_count: "Alunos Inscritos"
+      role:
+        name: "Nome"
+        description: "Descrição"
       allocation:
         day: "Dia"
         room: "Sala"


### PR DESCRIPTION
Fixing what @braganholo said about missing translations on closed pull request #29
![translated](https://f.cloud.github.com/assets/1538066/914767/128ebb76-fe4a-11e2-9d28-307cf0a74878.png)
