### PR TITLE
Escape HTML tags in Log View

### DIFF
--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -53,7 +53,7 @@ module VersionsHelper
 				end
 			end
 
-			property_list.html_safe
+			html_escape(property_list).gsub("&lt;br&gt;", "<br>").html_safe
 		end
 	end
 end


### PR DESCRIPTION
When a field with HTML appears in the Log view, the HTML isn't escaped, allowing XSS attacks. 

How to test:
Edit any field of a model with text "Word1<br>Word2"
Edit again to any other value.
Open Versions page: /versions
Click in "View" and it shows in the Old Version:
field: Word1
Word2
