### PR TITLE
Fix PDF report for classes with no allocations

### DIFF
--- a/app/helpers/course_classes_pdf_helper.rb
+++ b/app/helpers/course_classes_pdf_helper.rb
@@ -152,7 +152,6 @@ module CourseClassesPdfHelper
 
       if course_class.allocations.empty?
         (first..last).each do |index|
-          table_width << day_width
           course[index + 1 - first] = "*\n "
         end
         star = true


### PR DESCRIPTION
@leomurta, @braganholo, this PR fixes #164 

Classes with no allocations were wrongly inserting columns on the table, based on the days of the week. This behaviour was already implemented on the method, causing an max width overflow on Prawn.