### PR TITLE
#198: add .pdf extension to enrollments report

### DIFF
--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -236,7 +236,7 @@ class EnrollmentsController < ApplicationController
 
     respond_to do |format|
       format.pdf do
-        send_data render_to_string, :filename => I18n.t("pdf_content.enrollment.to_pdf.filename"), :type => 'application/pdf'
+        send_data render_to_string, :filename => "#{I18n.t('pdf_content.enrollment.to_pdf.filename')}.pdf", :type => 'application/pdf'
       end
     end
   end


### PR DESCRIPTION
Não tinha nenhum bug, estava faltando apenas a extensão .pdf no nome do arquivo mesmo.