### PR TITLE
Criação de declarações externas

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReportsController < ApplicationController
+  include ReportsHelper
+
   before_action :set_report, only: [:download, :download_by_identifier, :invalidate]
   before_action :check_downloadable, only: [:download, :download_by_identifier]
   authorize_resource
@@ -14,9 +16,17 @@ class ReportsController < ApplicationController
     config.show.columns = [:user, :file_name, :identifier, :created_at, :expires_at, :invalidated_by, :invalidated_at]
     config.update.columns = [:expires_at]
     config.columns = config.list.columns
+    config.list.sorting = { created_at: :desc }
     config.columns[:user].clear_link
     config.columns[:expires_at_or_invalid].label = I18n.t("activerecord.attributes.report.expires_at")
-    config.actions.exclude :create, :delete
+    config.create.columns = [:file_name, :document_title, :document_body, :expiration_in_months]
+    config.columns.add :document_body, :expiration_in_months
+    config.columns[:document_body].required = true
+    config.columns[:expiration_in_months].label = I18n.t("activerecord.attributes.report_configuration.expiration_in_months")
+    config.columns[:expiration_in_months].description = I18n.t("active_scaffold.expiration_in_months_description")
+    config.columns[:expires_at].description = I18n.t("active_scaffold.expires_at_description")
+    config.create.label = :create_report_label
+    config.actions.exclude :delete
     config.action_links.add "download",
                             label: "
         <i title='#{I18n.t("active_scaffold.download_link")}'
@@ -37,6 +47,15 @@ class ReportsController < ApplicationController
                    method: :put,
                    confirm: "Tem certeza que deseja invalidar este documento?",
                    ignore_method: :cant_download?
+  end
+
+  def before_create_save(record)
+    record.user = current_user
+    record.expires_at = Date.today + record.expiration_in_months.to_i.months if record.expiration_in_months.present?
+    document_data = { body: params[:record][:document_body], title: params[:record][:document_title], expiration_in_months: params[:record][:expiration_in_months] }
+    extension = File.extname(record.file_name)[1..-1]
+    record.file_name = record.file_name + ".pdf" unless extension == "pdf"
+    create_external_report_pdf(record, document_data)
   end
 
   def download

--- a/app/helpers/assertions_pdf_helper.rb
+++ b/app/helpers/assertions_pdf_helper.rb
@@ -20,14 +20,16 @@ module AssertionsPdfHelper
 
     text = format_text(bindings, template)
 
-    lines = pdf.text_box text, at: [(pdf.bounds.width - box_width) / 2, pdf.cursor], width: box_width, height: box_height, align: :justify, inline_format: true, dry_run: true
-
-    while lines.size > 0
-      not_printed_text_length = lines.map { |line| line[:text].length }.sum
-      text = text[-not_printed_text_length..-1]
-
-      pdf.start_new_page
+    pdf.font("Times-Roman", size: 12) do
       lines = pdf.text_box text, at: [(pdf.bounds.width - box_width) / 2, pdf.cursor], width: box_width, height: box_height, align: :justify, inline_format: true, dry_run: true
+
+      while lines.size > 0
+        not_printed_text_length = lines.map { |line| line[:text].length }.sum
+        text = text[-not_printed_text_length..-1]
+
+        pdf.start_new_page
+        lines = pdf.text_box text, at: [(pdf.bounds.width - box_width) / 2, pdf.cursor], width: box_width, height: box_height, align: :justify, inline_format: true, dry_run: true
+      end
     end
   end
 

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ReportsHelper
+  include PdfHelper
+
+  def create_external_report_pdf(report, document_data = {})
+    render_to_string(
+      template: "reports/external_report_pdf",
+      type: "application/pdf",
+      formats: [:pdf],
+      assigns: { report: report, title: document_data[:title], document_body: document_data[:body], expiration_in_months: document_data[:expiration_in_months] }
+    )
+  end
+
+  def report_body_text(pdf, document_body)
+    pdf.bounding_box([(pdf.bounds.width - 500) / 2, pdf.cursor], width: 500, height: pdf.bounds.height - 98) do
+      pdf.font("Times-Roman", size: 12) do
+        pdf.move_down 30
+
+        pdf.text document_body, align: :justify
+      end
+    end
+  end
+
+  def document_body_form_column(record, options)
+    text_area :record, :document_body, options.merge!(rows: 20, cols: 80)
+  end
+
+  def document_title_form_column(record, options)
+    text_field :record, :document_title, options.merge!(value: "DECLARAÇÃO")
+  end
+
+  def expiration_in_months_form_column(record, options)
+    merge_options = { min: 1, value: ReportConfiguration.where(use_at_assertion: true).order(order: :desc).first&.expiration_in_months }
+    number_field :record, :expiration_in_months, options.merge!(merge_options)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -248,7 +248,6 @@ class Ability
     alias_action :execute_now, :execute_now, :notify, to: :update
     if roles[:manager]
       can :manage, Ability::DOCUMENT_MODELS
-      cannot :update, Report unless roles[Role::ROLE_ADMINISTRADOR]
     end
     if roles[Role::ROLE_SECRETARIA]
       cannot :read, [ReportConfiguration]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class Report < ApplicationRecord
+  attr_accessor :document_title, :document_body, :expiration_in_months
   belongs_to :user, foreign_key: "generated_by_id"
   belongs_to :invalidated_by, foreign_key: "invalidated_by_id", class_name: "User", optional: true
   belongs_to :carrierwave_file, foreign_key: "carrierwave_file_id", class_name: "CarrierWave::Storage::ActiveRecord::ActiveRecordFile", optional: true
+
+  validates :file_name, presence: true
 
   def to_label
     "#{self.user.name} - #{I18n.l(self.created_at, format: '%d/%m/%Y %H:%M')}"

--- a/app/views/enrollments/academic_transcript_pdf.pdf.prawn
+++ b/app/views/enrollments/academic_transcript_pdf.pdf.prawn
@@ -12,7 +12,7 @@ new_document(
     :generate_report_without_watermark, @enrollment
   ),
   pdf_type: :transcript,
-  signature_override: can?(:override_report_signature_type, @enrollment) ? @signature_override : nil
+  override: can?(:override_report_signature_type, @enrollment) ? { signature_type: @signature_override }.compact : nil
 ) do |pdf|
   enrollment_student_header(pdf, enrollment: @enrollment)
 

--- a/app/views/enrollments/grades_report_pdf.pdf.prawn
+++ b/app/views/enrollments/grades_report_pdf.pdf.prawn
@@ -12,7 +12,7 @@ new_document(
     )
   ),
   pdf_type: :grades_report,
-  signature_override: can?(:override_report_signature_type, @enrollment) ? @signature_override : nil
+  override: can?(:override_report_signature_type, @enrollment) ? { signature_type: @signature_override }.compact : nil
 ) do |pdf|
   enrollment_student_header(pdf, enrollment: @enrollment)
 

--- a/app/views/reports/external_report_pdf.pdf.prawn
+++ b/app/views/reports/external_report_pdf.pdf.prawn
@@ -1,0 +1,16 @@
+# Copyright (c) Universidade Federal Fluminense (UFF).
+# This file is part of SAPOS. Please, consult the license terms in the LICENSE file.
+
+# frozen_string_literal: true
+
+require "prawn/measurement_extensions"
+
+new_document(
+  @report.file_name,
+  @title,
+  override: { signature_type: :qr_code, expiration_in_months: @expiration_in_months },
+  pdf_type: :assertion,
+  report: @report
+) do |pdf|
+  report_body_text(pdf, @document_body)
+end

--- a/config/locales/reports.pt-BR.yml
+++ b/config/locales/reports.pt-BR.yml
@@ -13,8 +13,15 @@ pt-BR:
         invalidated: "Invalidado"
         invalidated_at: "Data de Invalidação"
         invalidated_by: "Invalidado por"
+        document_title: "Título do Documento"
+        document_body: "Corpo do Documento"
 
     models:
       report:
         one: "Documento Assinado"
         other: "Documentos Assinados"
+
+  active_scaffold:
+    create_report_label: "Gerar Documento Assinado"
+    expiration_in_months_description: "Caso vazio, o documento não terá data de expiração."
+    expires_at_description: "O texto da validade no documento não será alterado."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,12 +37,13 @@ CustomVariable.create([
 
 ReportConfiguration.create([
   { name: "Boletim", scale: 1, x: 0, y: 0, order: 1,
-    signature_footer: true,
+    signature_type: :qr_code,
     use_at_report: false,
     use_at_transcript: false,
     use_at_grades_report: true,
     use_at_schedule: false,
     use_at_assertion: false,
+    expiration_in_months: 12,
     text: <<~TEXT
       <NOME DA UNIVERSIDADE>
       <NOME DO INSTITUTO>
@@ -50,12 +51,13 @@ ReportConfiguration.create([
     TEXT
   },
   { name: "Histórico", scale: 0.45, x: 5, y: 12, order: 1,
-    signature_footer: true,
+    signature_type: :qr_code,
     use_at_report: false,
     use_at_transcript: true,
     use_at_grades_report: false,
     use_at_schedule: false,
     use_at_assertion: false,
+    expiration_in_months: 12,
     text: <<~TEXT
       <NOME DA UNIVERSIDADE>
       <NOME DO INSTITUTO>
@@ -63,12 +65,13 @@ ReportConfiguration.create([
     TEXT
   },
   { name: "Padrão", scale: 1, x: 0, y: 0, order: 1,
-    signature_footer: true,
+    signature_type: :no_signature,
     use_at_report: true,
     use_at_transcript: false,
     use_at_grades_report: false,
     use_at_schedule: true,
     use_at_assertion: false,
+    expiration_in_months: nil,
     text: <<~TEXT
       <NOME DA UNIVERSIDADE>
       <NOME DO INSTITUTO>
@@ -76,12 +79,13 @@ ReportConfiguration.create([
     TEXT
   },
   { name: "Declaração", scale: 1, x: 0, y: 0, order: 1,
-    signature_footer: true,
+    signature_type: :manual,
     use_at_report: false,
     use_at_transcript: false,
     use_at_grades_report: false,
     use_at_schedule: false,
     use_at_assertion: true,
+    expiration_in_months: nil,
     text: <<~TEXT
       <NOME DA UNIVERSIDADE>
       <NOME DO INSTITUTO>

--- a/spec/factories/factory_report.rb
+++ b/spec/factories/factory_report.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :report do
     association :user, factory: :user
+    file_name { "report_#{SecureRandom.hex(4)}.pdf" }
     created_at { Time.now }
     expires_at { 1.year.from_now }
   end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -15,5 +15,10 @@ RSpec.describe Report, type: :model do
   describe "associations" do
     it { should belong_to(:user).with_foreign_key("generated_by_id") }
     it { should belong_to(:carrierwave_file).with_foreign_key("carrierwave_file_id").class_name("CarrierWave::Storage::ActiveRecord::ActiveRecordFile").optional }
+    it { should belong_to(:invalidated_by).with_foreign_key("invalidated_by_id").class_name("User").optional }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:file_name) }
   end
 end


### PR DESCRIPTION
Usuários com role :manager (Coordenação, Secretaria e Admin) podem agora criar uma declaração assinada escrevendo um plain text que será usado no corpo da declaração. Serve para declarações externas, que não tem necessidade de serem criadas como uma consulta com variáveis para usar nas Declarações customizáveis.
O usuário deve poder escolher:
- Nome do arquivo (usado pra identificação na listagem dos Documentos Assinados)
- Título da declaração (usado no cabeçalho da declaração, com padrão "DECLARAÇÃO")
- Corpo da declaração
- Validade (em meses) da declaração (padrão seguindo o configurado globalmente pra declarações)

Nesse PR também:
- corrijo o seeds.rb, que não foi atualizado após a inserção e remoção de atributos no model ReportConfiguration
- permito a edição da validade de Documentos Assinados por parte da secretaria (anteriormente somente por Coordenação e Admin)
- altero a fonte das declarações para Times New Roman tamanho 12.
