### PR TITLE
Geração de documentos por parte de alunos, visualização de declarações nas matrículas e validade configurável por declaração

### DIFF
--- a/app/controllers/assertions_controller.rb
+++ b/app/controllers/assertions_controller.rb
@@ -22,7 +22,7 @@ class AssertionsController < ApplicationController
                             type: :member
 
     form_columns = [
-      :name, :query, :assertion_template
+      :name, :student_can_generate, :query, :assertion_template, :expiration_in_months
     ]
 
     config.create.label = :create_assertion_label
@@ -32,6 +32,8 @@ class AssertionsController < ApplicationController
     config.update.columns = form_columns
     config.show.columns = form_columns
     config.actions.exclude :deleted_records
+
+    config.columns[:expiration_in_months].description = I18n.t("active_scaffold.expiration_in_months_description")
 
     config.columns[:query].form_ui = :select
   end
@@ -52,8 +54,15 @@ class AssertionsController < ApplicationController
     render action: "simulate"
   end
 
-  def assertion_pdf
+  def override_signature_assertion_pdf
+    assertion_pdf(params[:signature_type])
+  end
+
+  def assertion_pdf(signature_type = nil)
     @assertion = Assertion.find(params[:id])
+
+    authorize! :generate_assertion, @assertion, get_query_params[:matricula_aluno]
+
     args = @assertion.query.map_params(get_query_params)
     @assertion.args = args
 
@@ -62,7 +71,7 @@ class AssertionsController < ApplicationController
         title = I18n.t("pdf_content.assertion.assertion_pdf.filename")
         assertion = @assertion.name
         filename = "#{title} - #{assertion}.pdf"
-        send_data render_assertion_pdf(@assertion, filename),
+        send_data render_assertion_pdf(@assertion, filename, signature_type),
                   filename: filename,
                   type: "application/pdf"
       end
@@ -70,11 +79,10 @@ class AssertionsController < ApplicationController
   end
 
   private
-  def get_query_params
-    return params[:query_params].to_unsafe_h if params[:query_params].is_a?(
-      ActionController::Parameters
-    )
-    params[:query_params] || {}
-  end
-
+    def get_query_params
+      return params[:query_params].to_unsafe_h if params[:query_params].is_a?(
+        ActionController::Parameters
+      )
+      params[:query_params] || {}
+    end
 end

--- a/app/controllers/assertions_controller.rb
+++ b/app/controllers/assertions_controller.rb
@@ -76,6 +76,13 @@ class AssertionsController < ApplicationController
                   type: "application/pdf"
       end
     end
+  rescue ActionView::Template::Error => e
+    if e.cause.is_a?(Exceptions::EmptyQueryException)
+      redirect_back(fallback_location: root_path, flash: { warning: I18n.t("activerecord.errors.models.assertion.empty_query", matricula: get_query_params[:matricula_aluno]) })
+      return
+    end
+
+    raise e
   end
 
   private

--- a/app/controllers/concerns/shared_pdf_concern.rb
+++ b/app/controllers/concerns/shared_pdf_concern.rb
@@ -78,14 +78,15 @@ module SharedPdfConcern
     )
   end
 
-  def render_assertion_pdf(assertion, filename = "assertion.pdf")
+  def render_assertion_pdf(assertion, filename = "assertion.pdf", signature_override = nil)
     render_to_string(
       template: "assertions/assertion_pdf",
       type: "application/pdf",
       formats: [:pdf],
       assigns: {
         filename: filename,
-        assertion: assertion
+        assertion: assertion,
+        signature_override: signature_override
       }
     )
   end

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -144,7 +144,7 @@ class EnrollmentsController < ApplicationController
     ]
     config.update.columns = columns - [:phase_due_dates]
     config.show.columns = columns - [:accomplishments]
-    config.show.columns.add :academic_transcript, :grades_report
+    config.show.columns.add :documents
 
     config.actions.exclude :deleted_records
   end
@@ -243,6 +243,11 @@ class EnrollmentsController < ApplicationController
 
   def grades_report_pdf(signature_type = nil)
     enrollment = Enrollment.find(params[:id])
+
+    if cannot?(:grades_report_pdf, enrollment)
+      raise CanCan::AccessDenied
+    end
+
     respond_to do |format|
       format.pdf do
         title = I18n.t("pdf_content.enrollment.grades_report.title")

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -144,7 +144,9 @@ class EnrollmentsController < ApplicationController
     ]
     config.update.columns = columns - [:phase_due_dates]
     config.show.columns = columns - [:accomplishments]
+    config.columns.add :documents
     config.show.columns.add :documents
+    config.columns[:documents].label = I18n.t("activerecord.models.assertion.other")
 
     config.actions.exclude :deleted_records
   end

--- a/app/controllers/student_enrollment_controller.rb
+++ b/app/controllers/student_enrollment_controller.rb
@@ -55,6 +55,10 @@ class StudentEnrollmentController < ApplicationController
       "student_enrollment/show_scholarships",
       :scholarship_durations, @enrollment.scholarship_durations
     )
+    existing_partial(
+      "student_enrollment/show_documents",
+      :documents, @enrollment, allowed_assertions: Assertion.student_allowed
+    )
 
     render :show
   end

--- a/app/helpers/assertions_helper.rb
+++ b/app/helpers/assertions_helper.rb
@@ -20,4 +20,8 @@ module AssertionsHelper
     )
   end
 
+  def expiration_in_months_form_column(record, options)
+    merge_options = { min: 1, value: record.new_record? ? ReportConfiguration.where(use_at_assertion: true).order(order: :desc).first&.expiration_in_months : record.expiration_in_months }
+    number_field :record, :expiration_in_months, options.merge!(merge_options)
+  end
 end

--- a/app/helpers/assertions_pdf_helper.rb
+++ b/app/helpers/assertions_pdf_helper.rb
@@ -42,7 +42,8 @@ module AssertionsPdfHelper
     rows = results[:rows]
     columns = results[:columns]
 
-    if results[:rows].size == 1
+    raise Exceptions::EmptyQueryException if rows.empty?
+    if rows.size == 1
       bindings = {}.merge(Hash[columns.zip(rows.first)])
     else
       unique_columns = find_unique_columns(columns, rows)

--- a/app/helpers/assertions_pdf_helper.rb
+++ b/app/helpers/assertions_pdf_helper.rb
@@ -21,6 +21,7 @@ module AssertionsPdfHelper
     text = format_text(bindings, template)
 
     pdf.font("Times-Roman", size: 12) do
+      pdf.fill_color "000000"
       lines = pdf.text_box text, at: [(pdf.bounds.width - box_width) / 2, pdf.cursor], width: box_width, height: box_height, align: :justify, inline_format: true, dry_run: true
 
       while lines.size > 0

--- a/app/helpers/enrollments_helper.rb
+++ b/app/helpers/enrollments_helper.rb
@@ -340,13 +340,8 @@ module EnrollmentsHelper
     [:page, :update, :utf8]
   end
 
-  def academic_transcript_show_column(record, column)
-    render(partial: "enrollments/show_academic_transcript_signature_override_links",
-           locals: { record: record })
-  end
-
-  def grades_report_show_column(record, column)
-    render(partial: "enrollments/show_grades_report_signature_override_links",
-           locals: { record: record })
+  def documents_show_column(record, column)
+    render(partial: "enrollments/show_documents_table",
+           locals: { enrollment: record, allowed_assertions: Assertion.student_allowed })
   end
 end

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -345,15 +345,15 @@ module PdfHelper
         pdf.create_stamp("watermark") do
           pdf.rotate(60, origin: [0, 0]) do
             pdf.fill_color "993333"
-            pdf.font("FreeMono", size: 22) do
+            pdf.font("FreeMono", size: 25) do
               pdf.draw_text(
-                I18n.t("pdf_content.professor_watermark"), at: [0, 0]
+                I18n.t("pdf_content.watermark"), at: [0, 0]
               )
             end
             pdf.fill_color "000000"
           end
         end
-        pdf.repeat(:all, dynamic: true) do
+        pdf.repeat(:all) do
           pdf.stamp_at "watermark", [80, 0]
         end
       end

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -141,7 +141,7 @@ module PdfHelper
 
           all_sentences = [qrcode_signature_warning, signed_at, you_can_also_access, qrcode_url]
           if options[:expires_at]
-            valid_until = "#{I18n.t("pdf_content.enrollment.footer.valid_until")} #{I18n.l(Date.today + options[:expires_at].months, format: :default)}"
+            valid_until = "#{I18n.t("pdf_content.enrollment.footer.valid_until")} #{I18n.l(Date.today + options[:expires_at].months, format: :default)}."
             all_sentences.append(valid_until)
           end
 

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -15,6 +15,7 @@ module ReportsHelper
   def report_body_text(pdf, document_body)
     pdf.bounding_box([(pdf.bounds.width - 500) / 2, pdf.cursor], width: 500, height: pdf.bounds.height - 98) do
       pdf.font("Times-Roman", size: 12) do
+        pdf.fill_color "000000"
         pdf.move_down 30
 
         pdf.text document_body, align: :justify

--- a/app/models/assertion.rb
+++ b/app/models/assertion.rb
@@ -11,8 +11,19 @@ class Assertion < ApplicationRecord
 
   validates :name, presence: true
   validates :assertion_template, presence: true, on: :update
+  validate :only_student_enrollment_param, if: -> { self.student_can_generate }
+  validates :expiration_in_months, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+
+  scope :student_allowed, -> { where(student_can_generate: true) }
 
   def to_label
     "#{self.name}"
   end
+
+  private
+    def only_student_enrollment_param
+      if self.query.params.pluck(:name) != ["matricula_aluno"]
+        errors.add(:student_can_generate, :default_enrollment_variable_required)
+      end
+    end
 end

--- a/app/views/assertions/assertion_pdf.pdf.prawn
+++ b/app/views/assertions/assertion_pdf.pdf.prawn
@@ -6,10 +6,17 @@
 new_document(
   @filename,
   I18n.t("pdf_content.assertion.assertion_pdf.filename"),
-  pdf_type: :assertion
+  watermark: cannot?(
+    :generate_report_without_watermark, Enrollment
+  ),
+  pdf_type: :assertion,
+  override: if can?(:override_report_signature_type, Assertion)
+              { signature_type: @signature_override }.compact.merge({ expiration_in_months: @assertion.expiration_in_months })
+            else
+              { expiration_in_months: @assertion.expiration_in_months }
+            end
 ) do |pdf|
   assertion_table(
       pdf, assertion: @assertion
     )
-
 end

--- a/app/views/enrollments/_show_documents_table.html.erb
+++ b/app/views/enrollments/_show_documents_table.html.erb
@@ -1,0 +1,53 @@
+<table class="showtable listed-records-table">
+  <thead>
+  <tr>
+    <th><%= t "activerecord.models.assertion.one" %></th>
+    <% if can? :override_report_signature_type, Enrollment %>
+      <th>Sem ass.</th>
+      <th>Ass. manual</th>
+      <th>Ass. QR Code</th>
+    <% else %>
+      <th>Ação</th>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody class="records">
+  <% count = 0 %>
+  <tr class="record">
+    <td><%= t("pdf_content.enrollment.grades_report.link") %></td>
+    <% if can? :override_report_signature_type, Enrollment %>
+      <td><%= link_to 'Gerar', override_signature_grades_report_pdf_enrollment_path(id: enrollment.id, signature_type: :no_signature, format: :pdf), target: "_blank", method: :get %></td>
+      <td><%= link_to 'Gerar', override_signature_grades_report_pdf_enrollment_path(id: enrollment.id, signature_type: :manual, format: :pdf), target: "_blank", method: :get %></td>
+      <td><%= link_to 'Gerar', override_signature_grades_report_pdf_enrollment_path(id: enrollment.id, signature_type: :qr_code, format: :pdf), target: "_blank", method: :get %></td>
+    <% else %>
+      <td><%= link_to "Gerar", grades_report_pdf_enrollment_path(id: enrollment.id, format: :pdf), target: "_blank", method: :get %></td>
+    <% end %>
+  </tr>
+  <% if can?(:academic_transcript_pdf, enrollment) %>
+    <tr class="record">
+      <td><%= t("pdf_content.enrollment.academic_transcript.link") %></td>
+      <% if can? :override_report_signature_type, Enrollment %>
+        <td><%= link_to 'Gerar', override_signature_transcript_pdf_enrollment_path(id: enrollment.id, signature_type: :no_signature, format: :pdf), target: "_blank", method: :get %></td>
+        <td><%= link_to 'Gerar', override_signature_transcript_pdf_enrollment_path(id: enrollment.id, signature_type: :manual, format: :pdf), target: "_blank", method: :get %></td>
+        <td><%= link_to 'Gerar', override_signature_transcript_pdf_enrollment_path(id: enrollment.id, signature_type: :qr_code, format: :pdf), target: "_blank", method: :get %></td>
+      <% else %>
+        <td><%= link_to "Gerar", academic_transcript_pdf_enrollment_path(id: enrollment.id, format: :pdf), target: "_blank", method: :get %></td>
+      <% end %>
+    </tr>
+  <% end %>
+  <% allowed_assertions.each do |assertion| %>
+    <% count += 1 %>
+    <% tr_class = count.even? ? "even-record" : "" %>
+    <tr class="record <%= tr_class %>">
+      <td><%= assertion.name %></td>
+      <% if can? :override_report_signature_type, Enrollment %>
+        <td><%= link_to "Gerar", override_signature_assertion_pdf_assertion_path(id: assertion.id, query_params: {matricula_aluno: enrollment.enrollment_number}, signature_type: :no_signature, format: :pdf), target: "_blank", method: :get %></td>
+        <td><%= link_to "Gerar", override_signature_assertion_pdf_assertion_path(id: assertion.id, query_params: {matricula_aluno: enrollment.enrollment_number}, signature_type: :manual, format: :pdf), target: "_blank", method: :get %></td>
+        <td><%= link_to "Gerar", override_signature_assertion_pdf_assertion_path(id: assertion.id, query_params: {matricula_aluno: enrollment.enrollment_number}, signature_type: :qr_code, format: :pdf), target: "_blank", method: :get %></td>
+      <% else %>
+        <td><%= link_to "Gerar", assertion_pdf_assertion_path(id: assertion.id, query_params: {matricula_aluno: enrollment.enrollment_number}, format: :pdf), target: "_blank", method: :get %></td>
+      <% end %>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/queries/_sql_form_column.html.erb
+++ b/app/views/queries/_sql_form_column.html.erb
@@ -14,7 +14,9 @@
         </ul>
   			<span class="desc-title">Variáveis especiais: </span>
   			<ul>
-          <li>As variáveis especiais precisam ser definidas na consulta para poderem ser utilizadas em notificações</li>
+          <li>A variável especial abaixo precisa estar definida na consulta para que possa ser utilizada em declarações geradas por alunos</li>
+          <li><strong>:matricula_aluno</strong> <br> Número da matrícula do aluno. <br></li>
+          <li>As variáveis especiais abaixo precisam ser definidas na consulta para poderem ser utilizadas em notificações</li>
           <li><strong>:data_consulta</strong> <br> Data de consulta. <br> Ex: <strong>15/01/2014</strong>, para
             frequencia anual e offset de consulta 14d
           </li>

--- a/app/views/student_enrollment/_show_documents.html.erb
+++ b/app/views/student_enrollment/_show_documents.html.erb
@@ -1,0 +1,11 @@
+<div class="show-box">
+  <details open>
+    <summary> <%= t "activerecord.models.assertion.other" %> </summary>
+    <%= render partial: "enrollments/show_documents_table", locals: {
+      enrollment: @enrollment,
+      allowed_assertions: allowed_assertions,
+      dateformat: :monthyear,
+      show_obs: false
+    } %>
+  </details>
+</div>

--- a/app/views/student_enrollment/show.html.erb
+++ b/app/views/student_enrollment/show.html.erb
@@ -1,6 +1,6 @@
 <div class="landing-main">
-  <% if flash[:alert] %>
-      <div id="error_login"><%= flash[:alert] %></div>
+  <% if flash[:alert] || flash[:warning] %>
+      <div id="error_login"><%= flash[:alert] || flash[:warning] %></div>
   <% end %>
 
   <h2> <%= t(

--- a/config/locales/assertion.pt-BR.yml
+++ b/config/locales/assertion.pt-BR.yml
@@ -23,6 +23,7 @@ pt-BR:
       models:
         assertion:
           default_enrollment_variable_required: "A consulta deve conter somente uma variável: :matricula_aluno"
+          empty_query: "Não há dados no Sapos que permitam a geração dessa declaração para a matrícula %{matricula}. Por favor, entre em contato com a secretaria do curso."
 
     models:
       assertion:

--- a/config/locales/assertion.pt-BR.yml
+++ b/config/locales/assertion.pt-BR.yml
@@ -3,8 +3,8 @@
 
 pt-BR:
   active_scaffold:
+    create_assertion_label: "Adicionar Declaração"
     assertion:
-      create_assertion_label: "Adicionar Declaração"
       simulate: "Simular"
       generate_pdf: "Gerar PDF"
       query_date: "Data de Consulta"
@@ -16,6 +16,13 @@ pt-BR:
         query: "Consulta"
         params: "Parâmetros configuráveis da declaração"
         assertion_template: "Template do Corpo"
+        student_can_generate: "Pode ser gerada pelo aluno"
+        expiration_in_months: "Validade (meses)"
+
+    errors:
+      models:
+        assertion:
+          default_enrollment_variable_required: "A consulta deve conter somente uma variável: :matricula_aluno"
 
     models:
       assertion:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -143,7 +143,7 @@ pt-BR:
       justification_grade_not_count_in_gpr: "    Justificativa     "
 
   pdf_content:
-    professor_watermark: "DOCUMENTO VÁLIDO APENAS PARA USO INTERNO E PESSOAL DO PROFESSOR"
+    watermark: "DOCUMENTO PARA USO INTERNO E SEM VALOR OFICIAL"
 
   rescue_blank_text: "Não informado"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -527,6 +527,7 @@ Rails.application.routes.draw do
     member do
       get "simulate"
       get "assertion_pdf"
+      get "assertion_pdf/:signature_type.pdf", to: "assertions#override_signature_assertion_pdf",  as: :override_signature_assertion_pdf
     end
   end
 

--- a/db/migrate/20250117175508_add_student_can_generate_to_assertions.rb
+++ b/db/migrate/20250117175508_add_student_can_generate_to_assertions.rb
@@ -1,0 +1,9 @@
+class AddStudentCanGenerateToAssertions < ActiveRecord::Migration[7.0]
+  def up
+    add_column :assertions, :student_can_generate, :boolean, default: false
+  end
+
+  def down
+    remove_column :assertions, :student_can_generate
+  end
+end

--- a/db/migrate/20250119191848_add_expiration_in_months_to_assertions.rb
+++ b/db/migrate/20250119191848_add_expiration_in_months_to_assertions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddExpirationInMonthsToAssertions < ActiveRecord::Migration[7.0]
+  def up
+    add_column :assertions, :expiration_in_months, :integer, null: true
+  end
+
+  def down
+    remove_column :assertions, :expiration_in_months
+  end
+end

--- a/db/migrate/20250124003106_add_query_and_assertion_for_student_level_completion.rb
+++ b/db/migrate/20250124003106_add_query_and_assertion_for_student_level_completion.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class AddQueryAndAssertionForStudentLevelCompletion < ActiveRecord::Migration[7.0]
+  def up
+    query = {
+      name: "DECLARAÇÃO - Conclusão de nível",
+      description: "Declaração de conclusão de nível pelo aluno.",
+      params: [
+        {
+          name: "matricula_aluno",
+          value_type: "String",
+        }
+      ],
+      sql: <<~SQL
+        SELECT
+            s.name as nome_aluno,
+            s.cpf as cpf_aluno,
+            e.enrollment_number as matricula_aluno,
+            l.name as nivel_aluno,
+            e.thesis_title as titulo_tese,
+            e.thesis_defense_date as data_defesa_tese
+        FROM
+            enrollments e, students s, levels l, dismissals d, dismissal_reasons dr
+        WHERE
+            e.student_id = s.id AND
+            e.level_id = l.id AND
+            d.enrollment_id = e.id AND
+            d.dismissal_reason_id = dr.id AND
+            dr.thesis_judgement = 'Aprovado' AND
+            e.enrollment_number = :matricula_aluno;
+      SQL
+    }
+
+    query_obj = Query.new(query.except(:params))
+    query[:params].map do |query_param|
+      query_obj.params.build(query_param)
+    end
+    query_obj.save!
+
+    Assertion.reset_column_information
+    assertion = {
+      name: "Declaração de conclusão de nível pelo aluno",
+      query_id: query_obj.id,
+      assertion_template: "Declaramos, para os devidos fins, que <%= var('nome_aluno') %>, CPF: <%= var('cpf_aluno') %>, matrícula <%= var('matricula_aluno') %>, cumpriu todos os requisitos para obtenção do título de <%= var('nivel_aluno') == 'Doutorado' ? 'Doutor' : 'Mestre' %>, tendo defendido, com aprovação, a Dissertação intitulada \"<%= var('titulo_tese') %>\", em <%= localize(var('data_defesa_tese'), :longdate) %>.",
+    }
+    assertion_obj = Assertion.new(assertion)
+    assertion_obj.save!
+  end
+
+  def down
+    assertion = Assertion.find_by(name: "Declaração de conclusão de nível pelo aluno")
+    assertion.destroy if assertion
+
+    query = Query.find_by(name: "DECLARAÇÃO - Conclusão de nível")
+    query_param = QueryParam.where(query_id: query.id)
+    query_param.destroy_all if query_param
+
+    query.destroy if query
+  end
+end

--- a/db/migrate/20250124003106_add_query_and_assertion_for_student_level_completion.rb
+++ b/db/migrate/20250124003106_add_query_and_assertion_for_student_level_completion.rb
@@ -3,8 +3,8 @@
 class AddQueryAndAssertionForStudentLevelCompletion < ActiveRecord::Migration[7.0]
   def up
     query = {
-      name: "DECLARAÇÃO - Conclusão de nível",
-      description: "Declaração de conclusão de nível pelo aluno.",
+      name: "DECLARAÇÃO - Conclusão de curso",
+      description: "Declaração de conclusão de curso.",
       params: [
         {
           name: "matricula_aluno",
@@ -39,7 +39,7 @@ class AddQueryAndAssertionForStudentLevelCompletion < ActiveRecord::Migration[7.
 
     Assertion.reset_column_information
     assertion = {
-      name: "Declaração de conclusão de nível pelo aluno",
+      name: "Declaração de conclusão de curso",
       student_can_generate: true,
       query_id: query_obj.id,
       assertion_template: "Declaramos, para os devidos fins, que <%= var('nome_aluno') %>, CPF: <%= var('cpf_aluno') %>, matrícula <%= var('matricula_aluno') %>, cumpriu todos os requisitos para obtenção do título de <%= var('nivel_aluno') == 'Doutorado' ? 'Doutor' : 'Mestre' %>, tendo defendido, com aprovação, a Dissertação intitulada \"<%= var('titulo_tese') %>\", em <%= localize(var('data_defesa_tese'), :longdate) %>.",
@@ -49,10 +49,10 @@ class AddQueryAndAssertionForStudentLevelCompletion < ActiveRecord::Migration[7.
   end
 
   def down
-    assertion = Assertion.find_by(name: "Declaração de conclusão de nível pelo aluno")
+    assertion = Assertion.find_by(name: "Declaração de conclusão de curso")
     assertion.destroy if assertion
 
-    query = Query.find_by(name: "DECLARAÇÃO - Conclusão de nível")
+    query = Query.find_by(name: "DECLARAÇÃO - Conclusão de curso")
     query_param = QueryParam.where(query_id: query.id)
     query_param.destroy_all if query_param
 

--- a/db/migrate/20250124003106_add_query_and_assertion_for_student_level_completion.rb
+++ b/db/migrate/20250124003106_add_query_and_assertion_for_student_level_completion.rb
@@ -40,6 +40,7 @@ class AddQueryAndAssertionForStudentLevelCompletion < ActiveRecord::Migration[7.
     Assertion.reset_column_information
     assertion = {
       name: "Declaração de conclusão de nível pelo aluno",
+      student_can_generate: true,
       query_id: query_obj.id,
       assertion_template: "Declaramos, para os devidos fins, que <%= var('nome_aluno') %>, CPF: <%= var('cpf_aluno') %>, matrícula <%= var('matricula_aluno') %>, cumpriu todos os requisitos para obtenção do título de <%= var('nivel_aluno') == 'Doutorado' ? 'Doutor' : 'Mestre' %>, tendo defendido, com aprovação, a Dissertação intitulada \"<%= var('titulo_tese') %>\", em <%= localize(var('data_defesa_tese'), :longdate) %>.",
     }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_19_191848) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_24_003106) do
   create_table "accomplishments", force: :cascade do |t|
     t.integer "enrollment_id"
     t.integer "phase_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_09_162516) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_19_191848) do
   create_table "accomplishments", force: :cascade do |t|
     t.integer "enrollment_id"
     t.integer "phase_id"
@@ -286,6 +286,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_09_162516) do
     t.datetime "updated_at", null: false
     t.integer "query_id", null: false
     t.text "assertion_template"
+    t.boolean "student_can_generate", default: false
+    t.integer "expiration_in_months"
     t.index ["query_id"], name: "index_assertions_on_query_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ CustomVariable.create([
   { description: "País padrão de emissão da identidade", variable: "identity_issuing_country", value: "Brasil" },
   { description: "Texto no final do quadro de horários", variable: "class_schedule_text", value: "Alunos interessados em cursar disciplinas de Tópicos Avançados devem consultar os respectivos professores antes da matrícula." },
   { description: "E-mail de redirecionamento para as notificações", variable: "redirect_email", value: "" },
-  { description: "E-mail das resposta de emails automáticos", variable: "reply_to", value: "sapos@sapos.ic.uff.br"},
+  { description: "E-mail das resposta de emails automáticos", variable: "reply_to", value: "sapos@sapos.ic.uff.br" },
   { description: "Texto de rodapé da notificação",
     variable: "notification_footer",
     value: <<~TEXT
@@ -3202,6 +3202,50 @@ user = User.new do |u|
 end
 user.skip_confirmation!
 user.save!
+
+query = {
+  name: "DECLARAÇÃO - Conclusão de curso",
+  description: "Declaração de conclusão de curso.",
+  params: [
+    {
+      name: "matricula_aluno",
+      value_type: "String",
+    }
+  ],
+  sql: <<~SQL
+        SELECT
+            s.name as nome_aluno,
+            s.cpf as cpf_aluno,
+            e.enrollment_number as matricula_aluno,
+            l.name as nivel_aluno,
+            e.thesis_title as titulo_tese,
+            e.thesis_defense_date as data_defesa_tese
+        FROM
+            enrollments e, students s, levels l, dismissals d, dismissal_reasons dr
+        WHERE
+            e.student_id = s.id AND
+            e.level_id = l.id AND
+            d.enrollment_id = e.id AND
+            d.dismissal_reason_id = dr.id AND
+            dr.thesis_judgement = 'Aprovado' AND
+            e.enrollment_number = :matricula_aluno;
+  SQL
+}
+
+query_obj = Query.new(query.except(:params))
+query[:params].map do |query_param|
+  query_obj.params.build(query_param)
+end
+query_obj.save!
+
+Assertion.reset_column_information
+assertion = {
+  name: "Declaração de conclusão de curso",
+  student_can_generate: true,
+  query_id: query_obj.id,
+  assertion_template: "Declaramos, para os devidos fins, que <%= var('nome_aluno') %>, CPF: <%= var('cpf_aluno') %>, matrícula <%= var('matricula_aluno') %>, cumpriu todos os requisitos para obtenção do título de <%= var('nivel_aluno') == 'Doutorado' ? 'Doutor' : 'Mestre' %>, tendo defendido, com aprovação, a Dissertação intitulada \"<%= var('titulo_tese') %>\", em <%= localize(var('data_defesa_tese'), :longdate) %>.",
+}
+Assertion.create!(assertion)
 
 Institution.create([
   { name: "Associação de Ensino Superior do Piauí", code: "AESPI" },

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -12,4 +12,5 @@ module Exceptions
       super(msg)
     end
   end
+  class EmptyQueryException < StandardError; end
 end

--- a/spec/models/assertion_spec.rb
+++ b/spec/models/assertion_spec.rb
@@ -23,5 +23,6 @@ RSpec.describe Assertion, type: :model do
     it { should be_valid }
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:assertion_template).on(:update) }
+    it { should validate_numericality_of(:expiration_in_months).only_integer.is_greater_than(0).allow_nil }
   end
 end


### PR DESCRIPTION
Usuários com role :ALUNO devem poder gerar seus boletins, históricos (caso sua matrícula esteja desligada por titulação), e demais declarações que estejam marcadas para poderem ser geradas por aluno.
Alunos só podem gerar suas próprias declarações, com verificação através do CanCanCan.
Declarações (model Assertion) agora incluem um campo booleano :student_can_generate, e caso verdadeiro, é validado se a consulta utilizada possui somente uma variável e com nome predefinido: :matricula_aluno.
Os documentos gerados por alunos seguem a lógica dos documentos gerados por professores: caso a configuração global seja gerar com QR Code, são gerados com QR Code normalmente, caso não, são gerados com marca d'água.
Seguindo feedback, também foi adicionado:
- :managers e professores agora visualizam no "olhinho" de uma matrícula uma tabela com as declarações que podem ser geradas diretamente por ali. Essas declarações são as mesmas que podem ser geradas pelo aluno, seguindo os critérios citados acima.
- Declarações agora incluem um campo inteiro: :expiration_in_months, semelhante ao ReportConfiguration, em que, ao criar a declaração, pode-se escolher o tempo de expiração para as gerações subsequentes. O padrão desse campo é o valor definido no ReportConfiguration.

Resolve as issues: #519, #411, #526