### PR TITLE
Impedindo temporariamente a geração de documentos por alunos

### DIFF
--- a/app/controllers/student_enrollment_controller.rb
+++ b/app/controllers/student_enrollment_controller.rb
@@ -55,10 +55,11 @@ class StudentEnrollmentController < ApplicationController
       "student_enrollment/show_scholarships",
       :scholarship_durations, @enrollment.scholarship_durations
     )
-    existing_partial(
-      "student_enrollment/show_documents",
-      :documents, @enrollment, allowed_assertions: Assertion.student_allowed
-    )
+    # Voltar essa partial assim que alunos puderem gerar seus próprios documentos
+    # existing_partial(
+    #   "student_enrollment/show_documents",
+    #   :documents, @enrollment, allowed_assertions: Assertion.student_allowed
+    # )
 
     render :show
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -257,12 +257,13 @@ class Ability
     if roles[Role::ROLE_COORDENACAO]
       cannot :manage, ReportConfiguration
     end
-    if roles[Role::ROLE_ALUNO]
-      can :assertion_pdf, Assertion
-      can :generate_assertion, Assertion do |assertion, matricula_aluno|
-        assertion.student_can_generate && matricula_aluno.in?(user.student.enrollments.pluck(:enrollment_number))
-      end
-    end
+    # Voltar essas permissões assim que alunos puderem gerar seus próprios documentos
+    # if roles[Role::ROLE_ALUNO]
+    #   can :assertion_pdf, Assertion
+    #   can :generate_assertion, Assertion do |assertion, matricula_aluno|
+    #     assertion.student_can_generate && matricula_aluno.in?(user.student.enrollments.pluck(:enrollment_number))
+    #   end
+    # end
     if roles[Role::ROLE_PROFESSOR]
       can :assertion_pdf, Assertion
       can :generate_assertion, Assertion do |assertion|
@@ -295,10 +296,11 @@ class Ability
   def initialize_student_pages(user, roles)
     if roles.include?(Role::ROLE_ALUNO) && user.student.present?
       can [:show, :enroll, :save_enroll], :student_enrollment
-      can :academic_transcript_pdf, Enrollment do |enrollment|
-        enrollment.dismissal&.dismissal_reason&.thesis_judgement === DismissalReason::APPROVED && enrollment.student_id === user.student.id
-      end
-      can :grades_report_pdf, Enrollment, student_id: user.student.id
+      # Voltar essas permissões assim que alunos puderem gerar seus próprios documentos
+      # can :academic_transcript_pdf, Enrollment do |enrollment|
+      #   enrollment.dismissal&.dismissal_reason&.thesis_judgement === DismissalReason::APPROVED && enrollment.student_id === user.student.id
+      # end
+      # can :grades_report_pdf, Enrollment, student_id: user.student.id
     else
       cannot [:show, :enroll, :save_enroll], :student_enrollment
     end


### PR DESCRIPTION
Assim que terminada a feature de "versionamento" dos dados de nível do programa e instituição dos professores da banca, podemos descimentar estes trechos para liberar a feature novamente.