### PR TITLE
Issue 150

### DIFF
--- a/app/controllers/scholarship_durations_controller.rb
+++ b/app/controllers/scholarship_durations_controller.rb
@@ -202,10 +202,6 @@ class ScholarshipDurationsController < ApplicationController
       start_dt = Date.new(start_year.to_i, start_month.to_i)
       end_dt = Date.new(end_year.to_i, end_month.to_i)
 
-      # scholarship_durations = ScholarshipDuration.arel_table
-      # scholarship_suspensions = ScholarshipSuspension.arel_table
-      # scholarship_durations_id = ScholarshipDuration.arel_table[:id]
-
       if start_year == 1 && end_year == 1
         query = "(SELECT d.id
                 FROM scholarship_durations as d

--- a/app/helpers/enrollments_helper.rb
+++ b/app/helpers/enrollments_helper.rb
@@ -263,7 +263,7 @@ module EnrollmentsHelper
       locals: {
         thesis_defense_committee_professors: record.thesis_defense_committee_professors,
         thesis_defense_date: record.thesis_defense_date,
-        dismissal_date: record.dismissal.date
+        dismissal_date: record.dismissal&.date
       }
     )
   end

--- a/app/helpers/enrollments_pdf_helper.rb
+++ b/app/helpers/enrollments_pdf_helper.rb
@@ -615,9 +615,9 @@ module EnrollmentsPdfHelper
             "#{I18n.t("pdf_content.enrollment.thesis.defense_committee")} "
           ]]
           thesis_desense_committee.each do |professor|
-            dismissal_date =  enrollment.dismissal.date
+            dismissal_date =  enrollment.dismissal&.date
             date = thesis_defense_date || dismissal_date
-            affiliation = Affiliation.professor_date(professor, date&.to_date)&.last
+            affiliation = Affiliation.professor_date(professor, date&.to_date)&.last || Affiliation.of_professor(professor).last
             data_table_rows_defense_committee += [[
               "<b>#{professor.name} / #{rescue_blank_text(
                 affiliation&.institution, method_call: :name

--- a/app/helpers/scholarship_durations_helper.rb
+++ b/app/helpers/scholarship_durations_helper.rb
@@ -122,4 +122,50 @@ module ScholarshipDurationsHelper
     options[:class] = options[:class].sub("update_form", "text-input")
     text_field(:record, :scholarship, options)
   end
+
+  def suspended_search_column(record, options)
+    local_options = {
+        include_blank: true
+    }
+
+    start_month_html_options = {
+        id: "suspended_start_month",
+        name: "search[suspended][start_month]"
+    }
+    start_year_html_options = {
+        id: "suspended_start_year",
+        name: "search[suspended][start_year]"
+    }
+
+    end_month_html_options = {
+        id: "suspended_end_month",
+        name: "search[suspended][end_month]"
+    }
+    end_year_html_options = {
+        id: "suspended_end_year",
+        name: "search[suspended][end_year]"
+    }
+    current_year = Date.today.year
+    html = check_box_tag(
+      "search[suspended][use]", "yes", false, style: "vertical-align: sub;"
+    )
+    html += label_tag(
+      "search[suspended][use]",
+      I18n.t("activerecord.attributes.scholarship_duration.suspended_label1"),
+      style: "margin: 0 15px;"
+    )
+
+    html += select_month(local_options, local_options, start_month_html_options)
+    html += select_year(local_options, local_options.merge(start_year: current_year - 20, end_year: current_year + 20), start_year_html_options)
+
+    html += label_tag(
+      "search[suspended][use]",
+      I18n.t("activerecord.attributes.scholarship_duration.suspended_label2"),
+      style: "margin: 0 15px;"
+    )
+
+    html += select_month(local_options, local_options, end_month_html_options)
+    html += select_year(local_options, local_options.merge(start_year: current_year - 20, end_year: current_year + 20), end_year_html_options)
+    html
+  end
 end

--- a/app/helpers/scholarship_durations_helper.rb
+++ b/app/helpers/scholarship_durations_helper.rb
@@ -151,7 +151,7 @@ module ScholarshipDurationsHelper
     )
     html += label_tag(
       "search[suspended][use]",
-      I18n.t("activerecord.attributes.scholarship_duration.suspended_label1"),
+      I18n.t("activerecord.attributes.scholarship_duration.suspended_start_label"),
       style: "margin: 0 15px;"
     )
 
@@ -160,7 +160,7 @@ module ScholarshipDurationsHelper
 
     html += label_tag(
       "search[suspended][use]",
-      I18n.t("activerecord.attributes.scholarship_duration.suspended_label2"),
+      I18n.t("activerecord.attributes.scholarship_duration.suspended_end_label"),
       style: "margin: 0 15px;"
     )
 

--- a/app/views/enrollments/_show_defense_committee_table.html.erb
+++ b/app/views/enrollments/_show_defense_committee_table.html.erb
@@ -11,9 +11,10 @@
       <% count += 1 %>
       <% tr_class = count.even? ? "even-record" : "" %>
       <% date =  thesis_defense_date || dismissal_date %>
+      <% affiliation = Affiliation.professor_date(professor, date&.to_date)&.last || Affiliation.of_professor(professor)&.last %>
       <tr class="record <%= tr_class %>">
         <td><%= professor.name %></td>
-        <td><%= rescue_blank_text(Affiliation.professor_date(professor, date&.to_date)&.last&.institution, method_call: :name) %></td>
+        <td><%= rescue_blank_text(affiliation&.institution, method_call: :name) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/locales/scholarship_duration.pt-BR.yml
+++ b/config/locales/scholarship_duration.pt-BR.yml
@@ -21,6 +21,9 @@ pt-BR:
         sponsors: "Agência de Fomento"
         start_date: "Data de Início"
         obs: "Observação"
+        suspended: "Suspenso"
+        suspended_start_label: "a partir de"
+        suspended_end_label: "até"
 
     errors:
       models:

--- a/spec/features/scholarship_durations_spec.rb
+++ b/spec/features/scholarship_durations_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "ScholarshipDurations features", type: :feature do
     @destroy_all << @scholarship_type1 = FactoryBot.create(:scholarship_type, name: "Individual")
     @destroy_all << @scholarship_type2 = FactoryBot.create(:scholarship_type, name: "Projeto")
 
-    @destroy_all << @scholarship1 = FactoryBot.create(:scholarship, scholarship_number: "B1", level: @level2, sponsor: @sponsor1, start_date: 3.years.ago.at_beginning_of_month, end_date: 1.year.from_now.at_beginning_of_month, scholarship_type: @scholarship_type1)
-    @destroy_all << @scholarship2 = FactoryBot.create(:scholarship, scholarship_number: "B2", level: @level1, sponsor: @sponsor2, start_date: 3.years.ago.at_beginning_of_month, end_date: 4.years.from_now.at_beginning_of_month, scholarship_type: @scholarship_type1)
-    @destroy_all << @scholarship3 = FactoryBot.create(:scholarship, scholarship_number: "B3", level: @level1, sponsor: @sponsor1, start_date: 3.years.ago.at_beginning_of_month, end_date: 1.year.from_now.at_beginning_of_month, scholarship_type: @scholarship_type2)
+    @destroy_all << @scholarship1 = FactoryBot.create(:scholarship, scholarship_number: "B1", level: @level2, sponsor: @sponsor1, start_date: 8.years.ago.at_beginning_of_month, end_date: 1.year.from_now.at_beginning_of_month, scholarship_type: @scholarship_type1)
+    @destroy_all << @scholarship2 = FactoryBot.create(:scholarship, scholarship_number: "B2", level: @level1, sponsor: @sponsor2, start_date: 6.years.ago.at_beginning_of_month, end_date: 4.years.from_now.at_beginning_of_month, scholarship_type: @scholarship_type1)
+    @destroy_all << @scholarship3 = FactoryBot.create(:scholarship, scholarship_number: "B3", level: @level1, sponsor: @sponsor1, start_date: 6.years.ago.at_beginning_of_month, end_date: 1.year.from_now.at_beginning_of_month, scholarship_type: @scholarship_type2)
 
     @destroy_all << @student1 = FactoryBot.create(:student, name: "Ana")
     @destroy_all << @student2 = FactoryBot.create(:student, name: "Bia")
@@ -38,8 +38,12 @@ RSpec.describe "ScholarshipDurations features", type: :feature do
     @destroy_all << @enrollment4 = FactoryBot.create(:enrollment, enrollment_number: "M04", student: @student4, level: @level1, enrollment_status: @enrollment_status)
 
     @destroy_all << @record = FactoryBot.create(:scholarship_duration, enrollment: @enrollment1, scholarship: @scholarship1, start_date: 2.years.ago.at_beginning_of_month, end_date: 1.months.from_now.at_beginning_of_month)
-    @destroy_all << FactoryBot.create(:scholarship_duration, enrollment: @enrollment2, scholarship: @scholarship2, start_date: 3.years.ago.at_beginning_of_month, end_date: 2.years.ago.at_beginning_of_month)
-    @destroy_all << FactoryBot.create(:scholarship_duration, enrollment: @enrollment3, scholarship: @scholarship2, start_date: 1.years.ago.at_beginning_of_month, cancel_date: 6.months.from_now.at_beginning_of_month, end_date: 1.year.from_now.at_beginning_of_month)
+    @destroy_all << @scholarship_duration2 = FactoryBot.create(:scholarship_duration, enrollment: @enrollment2, scholarship: @scholarship2, start_date: 3.years.ago.at_beginning_of_month, end_date: 2.years.from_now.at_beginning_of_month)
+    @destroy_all << FactoryBot.create(:scholarship_duration, enrollment: @enrollment3, scholarship: @scholarship2, start_date: 6.years.ago.at_beginning_of_month, cancel_date: 5.years.ago.at_beginning_of_month, end_date: 4.years.ago.at_beginning_of_month)
+
+    @destroy_all << @scholarship_suspension1 = FactoryBot.create(:scholarship_suspension, scholarship_duration: @record, start_date: 1.year.ago.at_beginning_of_month, end_date: 6.months.ago.at_beginning_of_month)
+    @destroy_all << @scholarship_suspension2 = FactoryBot.create(:scholarship_suspension, scholarship_duration: @scholarship_duration2, start_date: 1.month.ago.at_beginning_of_month, end_date: 1.month.from_now.at_beginning_of_month)
+
 
     @destroy_all << @professor1 = FactoryBot.create(:professor, name: "Erica", cpf: "3")
     @destroy_all << FactoryBot.create(:advisement, enrollment: @enrollment1, professor: @professor1, main_advisor: true)
@@ -158,9 +162,9 @@ RSpec.describe "ScholarshipDurations features", type: :feature do
     end
 
     it "should be able to search by start_date" do
-      select_month_year("search_start_date", 1.years.ago.at_beginning_of_month)
+      select_month_year("search_start_date", 3.years.ago.at_beginning_of_month)
       click_button "Buscar"
-      expect(page.all("tr td.scholarship-column").map(&:text)).to eq ["B2"]
+      expect(page.all("tr td.scholarship-column").map(&:text)).to eq ["B1", "B2"]
     end
 
     it "should be able to search by end_date" do
@@ -170,7 +174,7 @@ RSpec.describe "ScholarshipDurations features", type: :feature do
     end
 
     it "should be able to search by cancel_date" do
-      select_month_year("search_cancel_date", 6.months.from_now.at_beginning_of_month)
+      select_month_year("search_cancel_date", 5.years.ago.at_beginning_of_month)
       click_button "Buscar"
       expect(page.all("tr td.scholarship-column").map(&:text)).to eq ["B2"]
     end
@@ -211,6 +215,31 @@ RSpec.describe "ScholarshipDurations features", type: :feature do
     it "should be able to search by active" do
       expect(page.all("select#search_active option").map(&:text)).to eq ["Todas", "Ativas", "Inativas"]
       find(:select, "search_active").find(:option, text: "Inativas").select_option
+      click_button "Buscar"
+      expect(page.all("tr td.scholarship-column").map(&:text)).to eq ["B2"]
+    end
+
+    it "should be able to search by suspended" do
+      find(:css, "#search_suspended_use").set(true)
+      click_button "Buscar"
+      expect(page.all("tr td.scholarship-column").map(&:text)).to eq ["B1", "B2"]
+    end
+
+    it "should be able to search by the time interval of suspension" do
+      find(:css, "#search_suspended_use").set(true)
+
+      start_year = 0.years.ago.year
+      find(:select, "suspended_start_year").find(:option, text: start_year.to_s).select_option
+
+      start_month = I18n.l(2.months.ago, format: "%B")
+      find(:select, "suspended_start_month").find(:option, text: start_month).select_option
+
+      end_year = 0.years.ago.year
+      find(:select, "suspended_end_year").find(:option, text: end_year.to_s).select_option
+
+      end_month = I18n.l(2.months.from_now, format: "%B")
+      find(:select, "suspended_end_month").find(:option, text: end_month).select_option
+
       click_button "Buscar"
       expect(page.all("tr td.scholarship-column").map(&:text)).to eq ["B2"]
     end


### PR DESCRIPTION
Como solicitado, foi adicionado a funcionalidade de pesquisar bolsas alocadas que têm suspensão ativa. Além disso, é possível filtrar através do intervalo de tempo, ou seja, caso uma bolsa alocada estava (ou estará) com a suspensão ativa entre duas datas, essa será mostrada.
 Além disso, é possível colocar somente a data inicial, assim apresentando todos os casos em que a suspensão está ativa após tal data, além da possibilidade de também filtrar suspensões que estavam ativas até determinada data.