### PR TITLE
Fix flaky record_select interactions in feature specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
     ffi (1.17.4)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86-mingw32)
     ffi (1.17.4-x86_64-linux-gnu)
     font-awesome-rails (4.7.0.8)
@@ -310,6 +311,8 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -516,6 +519,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.6.8)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.6.8-arm64-darwin)
     sqlite3 (1.6.8-x86_64-linux)
     ssrf_filter (1.5.0)
     stringio (3.2.0)
@@ -555,6 +559,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  arm64-darwin
   ruby
   x86-mingw32
   x86_64-linux

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,71 @@
+# Feature spec conventions: dealing with asynchronous UI
+
+Feature specs drive a real browser (Capybara + Selenium + Chrome) against an
+AJAX-heavy UI (ActiveScaffold + jQuery). The base problem behind every flaky
+test we have had is the same: **the test runs synchronously, the UI updates
+asynchronously**. We handle it with four complementary mechanisms, each at a
+different layer. Use the lowest-numbered mechanism that can express what you
+need.
+
+## 1. Waiting matchers — the default for assertions
+
+Capybara matchers and finders (`have_css`, `have_content`, `have_select`,
+`find`, …) retry until the condition holds or the wait time expires. Always
+prefer asserting on the *specific expected outcome*:
+
+```ruby
+expect(page).to have_css("tr td.name-column", count: 4)
+expect(page).to have_select("widget_record_city_", options: ["Selecione a cidade", "Niteroi", "Rio"])
+find(:select, "record_date_2i").find(:option, text: "Mar").select_option  # waits for the option
+```
+
+Avoid non-waiting reads as assertions on AJAX-rendered content: `page.all`,
+`first`, `.value`, `all(...).map(&:text)` evaluate the DOM at that instant and
+do not retry. They are only safe right after `visit` (server-rendered page) or
+after a waiting matcher / `click_*_and_wait` has already established the
+state. When a test using them flakes, convert to a waiting matcher (see the
+city widget and month/year helpers for examples).
+
+## 2. `click_button_and_wait` / `click_link_and_wait` — the default for clicks
+
+Use them instead of `click_button` / `click_link` whenever the click triggers
+AJAX (almost every ActiveScaffold action). They wait for `jQuery.active == 0`
+after the click; since ActiveScaffold fires the XHR synchronously in the click
+handler and updates the DOM in the success handler, the DOM is up to date when
+they return.
+
+They do **not** cover rendering deferred with `setTimeout` or animations —
+follow the click with a waiting matcher for the content you expect.
+
+## 3. Widget helpers — encapsulated JS-event timing
+
+Some widgets have races that neither layer above can see: handlers attached
+after the test interacts, dropdowns that only open on `focus`, keystrokes
+ignored while a dropdown is closed. The helpers in `spec/support` deal with
+those internally — always drive widgets through them instead of clicking and
+typing manually:
+
+- `fill_record_select` / `search_record_select` / `expect_to_have_record_select`
+- `expect_to_have_city_widget`
+- `select_month_year` / `select_month_year_i` / `expect_to_have_month_year_widget_i`
+
+`sleep` is a last resort: never in spec files, only inside helpers when there
+is no observable condition to wait for, and always with a comment.
+
+## 4. Driver-level retries — already in place, don't duplicate
+
+Chrome/Selenium defects are handled once, in `spec/support`:
+
+- Chrome 116+ CDP stale-node errors: retried by the `synchronize` patch in
+  `wait_for_ajax_helpers.rb`.
+- Clicks intercepted by a stray record-select dropdown: retried inside
+  `record_select_helpers.rb`.
+
+Do not add ad-hoc `rescue`/retry blocks in individual specs; if a new driver
+issue shows up, handle it in a support file so every spec benefits.
+
+## Migration policy
+
+New code follows the rules above. Old code that still uses non-waiting
+assertions keeps working under layer 2's protection — convert it
+opportunistically when you touch it or when it flakes, not in a big bang.

--- a/spec/features/professors_spec.rb
+++ b/spec/features/professors_spec.rb
@@ -170,7 +170,6 @@ RSpec.describe "Professors features", type: :feature do
     it "should have a datepicker for birthdate with a range starting 100 years ago" do
       expect(page).not_to have_selector("#ui-datepicker-div")
       find("#record_birthdate_").click
-      wait_for_ajax
       expect(page).to have_selector("#ui-datepicker-div", visible: true)
       expect(page.all("select.ui-datepicker-year option").map(&:text)).to include(100.years.ago.year.to_s)
     end

--- a/spec/features/report_configurations_spec.rb
+++ b/spec/features/report_configurations_spec.rb
@@ -109,27 +109,25 @@ RSpec.describe "ReportConfigurations features", type: :feature do
     end
 
     it "should be able to duplicate record with logo" do
-      expect(page.all("tr td.name-column").size).to eq 3
+      expect(page).to have_css("tr td.name-column", count: 3)
       find("#as_#{plural_name}-duplicate-#{@record.id}-link").click
-      wait_for_ajax
-      expect(page.all("tr td.name-column").size).to eq 4
+      expect(page).to have_css("tr td.name-column", count: 4)
       record = model.last
       accept_confirm { find("#as_#{plural_name}-destroy-#{record.id}-link").click }
-      sleep(0.2)
+      expect(page).to have_css("tr td.name-column", count: 3)
       visit current_path
-      expect(page.all("tr td.name-column").size).to eq 3
+      expect(page).to have_css("tr td.name-column", count: 3)
     end
 
     it "should be able to duplicate record without logo" do
-      expect(page.all("tr td.name-column").size).to eq 3
+      expect(page).to have_css("tr td.name-column", count: 3)
       find("#as_#{plural_name}-duplicate-#{@record2.id}-link").click
-      wait_for_ajax
-      expect(page.all("tr td.name-column").size).to eq 4
+      expect(page).to have_css("tr td.name-column", count: 4)
       record = model.last
       accept_confirm { find("#as_#{plural_name}-destroy-#{record.id}-link").click }
-      sleep(0.2)
+      expect(page).to have_css("tr td.name-column", count: 3)
       visit current_path
-      expect(page.all("tr td.name-column").size).to eq 3
+      expect(page).to have_css("tr td.name-column", count: 3)
     end
   end
 

--- a/spec/support/date_helpers.rb
+++ b/spec/support/date_helpers.rb
@@ -22,10 +22,13 @@ module DateHelpers
     find(:select, "#{field}_year").find(:option, text: date.year.to_s).select_option
   end
 
+  # Uses waiting matchers (have_select) instead of page.all, which asserted on
+  # whatever was in the DOM at that instant and failed if the AJAX-loaded form
+  # had not rendered the widget yet.
   def expect_to_have_month_year_widget_i(record, field, blank = nil)
     months = ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"]
     months = [blank] + months unless blank.nil?
-    expect(page.all("select#record_#{field}_2i option").map(&:text)).to eq months
-    expect(page.all("select#record_#{field}_1i option").map(&:text)).to include(1.years.ago.year.to_s, 1.years.since.year.to_s)
+    expect(page).to have_select("record_#{field}_2i", options: months)
+    expect(page).to have_select("record_#{field}_1i", with_options: [1.years.ago.year.to_s, 1.years.since.year.to_s])
   end
 end

--- a/spec/support/place_widgets_helpers.rb
+++ b/spec/support/place_widgets_helpers.rb
@@ -15,42 +15,40 @@ module PlaceWidgetsHelpers
     destroy_later << FactoryBot.create(:city, name: "Campinas", state: state12)
   end
 
+  # Uses waiting matchers (have_select) instead of wait_for_ajax + page.all,
+  # which asserted on whatever was in the DOM at that instant and failed if
+  # the cascade AJAX had not repopulated the options yet. Selecting an option
+  # that only exists after a cascade (e.g. "RJ" after picking "Brasil") also
+  # waits, because find(:option, text:) retries until the option appears.
   def expect_to_have_city_widget(page, city_field, state_field, country_field)
-    expect(page.all("select#widget_record_#{city_field} option").map(&:text)).to eq ["Selecione a cidade"]
-    expect(page.all("select#widget_record_#{state_field} option").map(&:text)).to eq ["Selecione o estado"]
-    expect(page.all("select#widget_record_#{country_field} option").map(&:text)).to eq ["Selecione o país", "Brasil", "USA"]
+    city_select = "widget_record_#{city_field}"
+    state_select = "widget_record_#{state_field}"
+    country_select = "widget_record_#{country_field}"
 
-    find(:select, "widget_record_#{country_field}").find(:option, text: "Brasil").select_option
-    wait_for_ajax
-    expect(page.all("select#widget_record_#{state_field} option").map(&:text)).to eq ["Selecione o estado", "RJ", "SP"]
-    find(:select, "widget_record_#{country_field}").find(:option, text: "Selecione o país").select_option
-    wait_for_ajax
-    expect(page.all("select#widget_record_#{state_field} option").map(&:text)).to eq ["Selecione o estado"]
-    find(:select, "widget_record_#{country_field}").find(:option, text: "Brasil").select_option
-    wait_for_ajax
+    expect(page).to have_select(city_select, options: ["Selecione a cidade"])
+    expect(page).to have_select(state_select, options: ["Selecione o estado"])
+    expect(page).to have_select(country_select, options: ["Selecione o país", "Brasil", "USA"])
 
-    find(:select, "widget_record_#{state_field}").find(:option, text: "RJ").select_option
-    wait_for_ajax
-    expect(page.all("select#widget_record_#{city_field} option").map(&:text)).to eq ["Selecione a cidade", "Niteroi", "Rio"]
-    find(:select, "widget_record_#{state_field}").find(:option, text: "Selecione o estado").select_option
-    wait_for_ajax
-    expect(page.all("select#widget_record_#{city_field} option").map(&:text)).to eq ["Selecione a cidade"]
-    find(:select, "widget_record_#{state_field}").find(:option, text: "RJ").select_option
-    wait_for_ajax
+    find(:select, country_select).find(:option, text: "Brasil").select_option
+    expect(page).to have_select(state_select, options: ["Selecione o estado", "RJ", "SP"])
+    find(:select, country_select).find(:option, text: "Selecione o país").select_option
+    expect(page).to have_select(state_select, options: ["Selecione o estado"])
+    find(:select, country_select).find(:option, text: "Brasil").select_option
 
-    find(:select, "widget_record_#{city_field}").find(:option, text: "Niteroi").select_option
-    wait_for_ajax
-    find(:select, "widget_record_#{state_field}").find(:option, text: "Selecione o estado").select_option
-    wait_for_ajax
-    expect(page.all("select#widget_record_#{city_field} option").map(&:text)).to eq ["Selecione a cidade"]
-    find(:select, "widget_record_#{state_field}").find(:option, text: "RJ").select_option
-    wait_for_ajax
-    find(:select, "widget_record_#{city_field}").find(:option, text: "Niteroi").select_option
-    wait_for_ajax
-    find(:select, "widget_record_#{country_field}").find(:option, text: "Selecione o país").select_option
-    wait_for_ajax
-    expect(page.all("select#widget_record_#{state_field} option").map(&:text)).to eq ["Selecione o estado"]
-    expect(page.all("select#widget_record_#{city_field} option").map(&:text)).to eq ["Selecione a cidade"]
+    find(:select, state_select).find(:option, text: "RJ").select_option
+    expect(page).to have_select(city_select, options: ["Selecione a cidade", "Niteroi", "Rio"])
+    find(:select, state_select).find(:option, text: "Selecione o estado").select_option
+    expect(page).to have_select(city_select, options: ["Selecione a cidade"])
+    find(:select, state_select).find(:option, text: "RJ").select_option
+
+    find(:select, city_select).find(:option, text: "Niteroi").select_option
+    find(:select, state_select).find(:option, text: "Selecione o estado").select_option
+    expect(page).to have_select(city_select, options: ["Selecione a cidade"])
+    find(:select, state_select).find(:option, text: "RJ").select_option
+    find(:select, city_select).find(:option, text: "Niteroi").select_option
+    find(:select, country_select).find(:option, text: "Selecione o país").select_option
+    expect(page).to have_select(state_select, options: ["Selecione o estado"])
+    expect(page).to have_select(city_select, options: ["Selecione a cidade"])
   end
 
   def expect_to_have_identity_issuing_place_widget(page, field, record_id = "")

--- a/spec/support/record_select_helpers.rb
+++ b/spec/support/record_select_helpers.rb
@@ -3,15 +3,14 @@
 
 module RecordSelectHelpers
   def search_record_select(field, plural, value)
-    record_select = find("#search_#{field}").click
-    wait_for_ajax
+    record_select = open_record_select("#search_#{field}", plural)
     record_select.send_keys value
     sleep(0.5)
     find("#record-select-#{plural} .current").click
   end
 
   def fill_record_select(field, plural, value)
-    record_select = find("#record_#{field}").click
+    record_select = open_record_select("#record_#{field}", plural)
     record_select.native.clear
     record_select.send_keys value
     sleep(0.5)
@@ -19,8 +18,37 @@ module RecordSelectHelpers
   end
 
   def expect_to_have_record_select(page, field, plural)
-    find("#record_#{field}").click
-    sleep(0.3)
+    click_record_select_input("#record_#{field}")
     expect(page).to have_selector("#record-select-#{plural}", visible: true)
+  end
+
+  # Clicks the record-select input and waits until its dropdown is open with
+  # records loaded. RecordSelect ignores keystrokes while the dropdown is
+  # closed (onkeyup checks is_open), so typing before the open AJAX completes
+  # would be silently lost.
+  def open_record_select(selector, plural)
+    input = click_record_select_input(selector)
+    find("#record-select-#{plural} li.record", match: :first)
+    input
+  end
+
+  # RecordSelect auto-opens its dropdown when ActiveScaffold focuses the first
+  # form field, and if the form is still being positioned the dropdown may end
+  # up overlapping the input. Selenium then rejects the click without it ever
+  # reaching the page, so the dropdown never closes and every retry fails.
+  # Pressing Escape closes the stray dropdown; the input must also be blurred,
+  # otherwise the retried click fires no focus event and the dropdown (which
+  # only opens on focus) would never reopen.
+  def click_record_select_input(selector)
+    input = find(selector)
+    begin
+      input.click
+    rescue Selenium::WebDriver::Error::ElementClickInterceptedError
+      page.send_keys :escape
+      page.execute_script("document.activeElement.blur()")
+      sleep(0.2)
+      input.click
+    end
+    input
   end
 end

--- a/spec/support/record_select_helpers.rb
+++ b/spec/support/record_select_helpers.rb
@@ -18,7 +18,8 @@ module RecordSelectHelpers
   end
 
   def expect_to_have_record_select(page, field, plural)
-    click_record_select_input("#record_#{field}")
+    input = click_record_select_input("#record_#{field}")
+    ensure_record_select_open(input, plural)
     expect(page).to have_selector("#record-select-#{plural}", visible: true)
   end
 
@@ -28,8 +29,20 @@ module RecordSelectHelpers
   # would be silently lost.
   def open_record_select(selector, plural)
     input = click_record_select_input(selector)
+    ensure_record_select_open(input, plural)
     find("#record-select-#{plural} li.record", match: :first)
     input
+  end
+
+  # A click only opens the dropdown through the focus event; if the field was
+  # already focused (ActiveScaffold autofocuses the first form field) or the
+  # RecordSelect observers were not attached yet, the click opens nothing.
+  # Blur and click again in that case.
+  def ensure_record_select_open(input, plural)
+    return if page.has_selector?("#record-select-#{plural}", visible: true)
+    page.execute_script("document.activeElement.blur()")
+    sleep(0.2)
+    input.click
   end
 
   # RecordSelect auto-opens its dropdown when ActiveScaffold focuses the first


### PR DESCRIPTION
## Problema

O workflow [Flaky tests (multi-trial)](https://github.com/gems-uff/sapos/actions/runs/27303900836) falhou em 3 de 10 trials, sempre no mesmo teste (`advisements_spec.rb:99`), com `ElementClickInterceptedError`: o clique no campo de professor era interceptado por um `<li>` de um dropdown do RecordSelect.

## Causa raiz

O RecordSelect abre o dropdown automaticamente quando o ActiveScaffold foca o primeiro campo do formulário. Se isso ocorre enquanto o formulário ainda está se posicionando, o dropdown fica sobreposto ao próprio input. O Selenium rejeita o clique sem que ele chegue à página — e como o clique nunca chega, o handler que fecharia o dropdown nunca dispara, e todas as retentativas do Capybara falham até o timeout.

A investigação expôs ainda duas outras corridas no mesmo helper:

- O `onkeyup` do RecordSelect descarta teclas com o dropdown fechado, então digitar antes do AJAX de abertura completar perdia a digitação silenciosamente.
- O clique só abre o dropdown via evento `focus`; se o campo já estava focado (autofocus) ou os observers ainda não estavam anexados, o clique não abria nada (causa das falhas no teste da linha 120 na primeira validação no CI).

## Correção

Em `spec/support/record_select_helpers.rb` (usado por 16 specs de features):

- Clique interceptado → Escape fecha o dropdown perdido, desfoca o input (para o novo clique disparar `focus`) e clica de novo.
- Espera o dropdown abrir com registros carregados antes de digitar.
- Se o dropdown não aparecer após o clique, desfoca e clica novamente.

## Endurecimento adicional (auditoria do mesmo padrão)

Uma auditoria dos demais usos de `wait_for_ajax` encontrou asserções não-esperantes (`page.all(...).map(&:text)` / `.size`) sobre conteúdo carregado via AJAX — elas avaliam o DOM no instante da chamada, sem retentar. Foram convertidas para matchers esperantes do Capybara:

- `place_widgets_helpers.rb`: verificações da cascata país→estado→cidade agora usam `have_select(options:)`; a seleção de opções cascateadas já espera via `find(:option, text:)`.
- `date_helpers.rb` (`expect_to_have_month_year_widget_i`, 9 usos): convertido para `have_select`.
- `report_configurations_spec.rb`: contagens de linha com `have_css(count:)`; elimina um `sleep(0.2)` que corria contra o AJAX do destroy.
- `professors_spec.rb`: remove `wait_for_ajax` inútil após abrir o datepicker (não há AJAX envolvido).

Os helpers `click_button_and_wait`/`click_link_and_wait` foram mantidos — o problema não está neles, e sim nas asserções não-esperantes que vinham depois.

Também adiciona a plataforma `arm64-darwin` ao `Gemfile.lock` para permitir gems pré-compiladas em Apple Silicon.

## Validação

- CI: duas rodadas consecutivas do workflow Flaky tests com **20/20 trials verdes** (2033 exemplos por trial) — [rodada 1](https://github.com/gems-uff/sapos/actions/runs/27314900872) após a correção do RecordSelect e [rodada 2](https://github.com/gems-uff/sapos/actions/runs/27315800907) após o endurecimento — contra 7/10 antes da correção.
- Local: 10/10 execuções do teste originalmente flaky, 10/10 do teste da linha 120, 16 specs que usam os helpers de record select verdes (211 exemplos) e os 9 arquivos afetados pelo endurecimento verdes (149 exemplos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Convenções documentadas

`spec/README.md` (novo) documenta a convenção para specs de feature contra UI assíncrona: matchers esperantes como padrão para asserções, `click_*_and_wait` como padrão para cliques que disparam AJAX, helpers de widget encapsulando corridas de eventos JS, retries de driver centralizados em `spec/support`, `sleep` apenas como último recurso dentro de helpers, e migração oportunista do código antigo.

