### PR TITLE
Limpa cache temporário do CarrierWave na manutenção (uploads/tmp)

### DIFF
--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -5,8 +5,22 @@ namespace :maintenance do
   task run: [:environment] do
     Rails.logger.info "[Maintenance] #{Time.now.to_fs} - Starting maintenance tasks"
     Rake::Task["maintenance:remove_expired_reports"].invoke
+    Rake::Task["maintenance:clean_upload_cache"].invoke
     Rake::Task["maintenance:trigger_notifications"].invoke
     Rails.logger.info "[Maintenance] #{Time.now.to_fs} - Finished maintenance tasks"
+  end
+
+  desc "Removes stale CarrierWave upload cache (default: older than 24h)"
+  task clean_upload_cache: [:environment] do
+    Rails.logger.info "[UploadCache] #{Time.now.to_fs} - Cleaning stale CarrierWave cache"
+    # The uploaders set config.root = Rails.root, so the file cache lives in
+    # Rails.root/uploads/tmp. CarrierWave.clean_cached_files! would use the base
+    # uploader (root = public/) and scan the wrong directory, so we clean from the
+    # actual uploader classes. clean_cached_files! only removes cache entries older
+    # than the threshold (default 24h), never touching DB blobs or stored uploads.
+    # The maintenance cron runs daily, so 24h is a safe margin for ongoing uploads.
+    [FormFileUploader, ImageUploader].each(&:clean_cached_files!)
+    Rails.logger.info "[UploadCache] #{Time.now.to_fs} - Finished cleaning cache"
   end
 
   task remove_expired_reports: [:environment] do


### PR DESCRIPTION
## O que

Adiciona a sub-task `maintenance:clean_upload_cache` em `lib/tasks/maintenance.rake`, invocada por `maintenance:run`, que remove o cache obsoleto do CarrierWave (mais antigo que 24h, padrão do gem).

Fixes #618

## Por que

Os uploaders (`FormFileUploader` e `ImageUploader`) usam `cache_storage :file`, então cada upload deixa uma cópia temporária em `uploads/tmp/` que **nunca era limpa** — acumulando indefinidamente (arquivos de 2023 em diante, centenas de MB por instância em produção). O conteúdo permanente vai como BLOB no MySQL (`carrier_wave_files`), então `uploads/tmp/` é descartável.

Como o cron de manutenção roda 1×/dia, o limite padrão de 24h é seguro e não remove uploads de submissões em andamento recentes. Após o deploy, o acúmulo histórico é removido na primeira execução.

## Detalhe importante

Os uploaders sobrescrevem `config.root = Rails.root`, então o cache real fica em `Rails.root/uploads/tmp/`. O método global `CarrierWave.clean_cached_files!` usa o uploader **base** (root = `public/`) e olharia para `public/uploads/tmp/` — diretório errado e vazio, sem efeito. Por isso a limpeza é feita a partir das classes de uploader corretas, que apontam para `Rails.root/uploads/tmp/`. `clean_cached_files!` remove apenas entradas de cache mais antigas que o limite; não toca em BLOBs do banco nem em uploads consolidados.

## Como foi testado

- Reproduzido o cenário criando uma entrada de cache de 3 dias e uma recente em `uploads/tmp/`.
- `bundle exec rails maintenance:clean_upload_cache` → a entrada de 3 dias foi removida, a recente permaneceu.
- `bundle exec rubocop lib/tasks/maintenance.rake` → sem offenses.
- `bundle exec rails -T maintenance` → ambas as tasks registradas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
